### PR TITLE
FGAAuthorizer: expose on_unauthorized handler

### DIFF
--- a/examples/authorization-for-tools/langchain-examples/src/agents/tools/buy.py
+++ b/examples/authorization-for-tools/langchain-examples/src/agents/tools/buy.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from pydantic import BaseModel
 from langchain_core.tools import StructuredTool
 from langchain_core.runnables import ensure_config
-from langchain_auth0_ai.fga.fga_authorizer import AuthParams, FGAAuthorizer, FGAAuthorizerOptions
+from langchain_auth0_ai.fga.fga_authorizer import FGAAuthorizer, FGAAuthorizerOptions
 
 class BuySchema(BaseModel):
     ticker: str
@@ -10,28 +10,28 @@ class BuySchema(BaseModel):
 
 fga = FGAAuthorizer.create()
 
-async def build_fga_query(params):
+async def build_fga_query(tool_input):
     user_id = ensure_config().get("configurable",{}).get("user_id")
     return {
         "user": f"user:{user_id}",
-        "object": f"asset:{params.get("ticker")}",
+        "object": f"asset:{tool_input["ticker"]}",
         "relation": "can_buy",
         "context": {"current_time": datetime.now(timezone.utc).isoformat()}
     }
 
+def on_unauthorized(tool_input):
+    return f"The user is not allowed to buy {tool_input["qty"]} shares of {tool_input["ticker"]}."
+
 use_fga = fga(FGAAuthorizerOptions(
-    build_query=build_fga_query
+    build_query=build_fga_query,
+    on_unauthorized=on_unauthorized,
 ))
 
-async def buy_tool_function(auth: AuthParams, ticker: str, qty: int) -> str:
-    allowed = auth.get("allowed", False)
-    if allowed:
-        # TODO: implement buy operation
-        return f"Purchased {qty} shares of {ticker}"
-    
-    return f"The user is not allowed to buy {ticker}."
+async def buy_tool_function(ticker: str, qty: int) -> str:
+    # TODO: implement buy operation
+    return f"Purchased {qty} shares of {ticker}"
 
-func=use_fga(buy_tool_function, on_error=lambda err: f"Unexpected error from buy tool: {err}")
+func=use_fga(buy_tool_function)
 
 buy_tool = StructuredTool(
     name="buy",

--- a/examples/authorization-for-tools/llama-index-examples/src/tools/buy.py
+++ b/examples/authorization-for-tools/llama-index-examples/src/tools/buy.py
@@ -1,32 +1,32 @@
 from datetime import datetime, timezone
 from llama_index.core.tools import FunctionTool
-from langchain_auth0_ai.fga.fga_authorizer import AuthParams, FGAAuthorizer, FGAAuthorizerOptions
+from langchain_auth0_ai.fga.fga_authorizer import FGAAuthorizer, FGAAuthorizerOptions
 from ..context import Context
 
 def buy_tool (context: Context):
     fga = FGAAuthorizer.create()
 
-    def build_fga_query(params):
+    def build_fga_query(tool_input):
         return {
             "user": f"user:{context.get("user_id")}",
-            "object": f"asset:{params.get("ticker")}",
+            "object": f"asset:{tool_input["ticker"]}",
             "relation": "can_buy",
             "context": {"current_time": datetime.now(timezone.utc).isoformat()}
         }
+    
+    def on_unauthorized(tool_input):
+        return f"The user is not allowed to buy {tool_input["qty"]} shares of {tool_input["ticker"]}."
 
     use_fga = fga(FGAAuthorizerOptions(
-        build_query=build_fga_query
+        build_query=build_fga_query,
+        on_unauthorized=on_unauthorized,
     ))
 
-    async def buy_tool_function(auth: AuthParams, ticker: str, qty: int) -> str:
-        allowed = auth.get("allowed", False)
-        if allowed:
-            # TODO: implement buy operation
-            return f"Purchased {qty} shares of {ticker}"
-        
-        return f"The user is not allowed to buy {ticker}."
+    async def buy_tool_function(ticker: str, qty: int) -> str:
+        # TODO: implement buy operation
+        return f"Purchased {qty} shares of {ticker}"
 
-    func=use_fga(buy_tool_function, on_error=lambda err: f"Unexpected error from buy tool: {err}")
+    func=use_fga(buy_tool_function)
 
     return FunctionTool.from_defaults(
         fn=func,

--- a/packages/auth0-ai/auth0_ai/authorizers/types.py
+++ b/packages/auth0-ai/auth0_ai/authorizers/types.py
@@ -1,11 +1,5 @@
-from typing import Concatenate, ParamSpec, TypedDict, Optional, Any, Callable, Awaitable, TypeVar, Union
+from typing import TypedDict, Optional, Any
 
 class AuthParams(TypedDict):
-  allowed: Optional[bool]
   access_token: Optional[str]
   claims: Optional[Any]
-
-ToolInput = ParamSpec("ToolInput")
-ToolOutput = TypeVar("ToolOutput")
-
-ToolWithAuthHandler = Callable[Concatenate[AuthParams, ToolInput], Union[ToolOutput, Awaitable[ToolOutput]]]

--- a/packages/langchain-auth0-ai/README.md
+++ b/packages/langchain-auth0-ai/README.md
@@ -72,7 +72,7 @@ Example [Authorization for Tools](../../examples/authorization-for-tools/langcha
 1. Create an instance of FGA Authorizer:
 
 ```python
-from langchain_auth0_ai.fga.fga_authorizer import AuthParams, FGAAuthorizer, FGAAuthorizerOptions
+from langchain_auth0_ai.fga.fga_authorizer import FGAAuthorizer, FGAAuthorizerOptions
 
 fga = FGAAuthorizer.create()
 ```
@@ -85,39 +85,39 @@ FGA_CLIENT_ID="<fga-client-id>"
 FGA_CLIENT_SECRET="<fga-client-secret>"
 ```
 
-2. Define the FGA query:
+2. Define the FGA query (`build_query`) and, optionally, the `on_unauthorized` handler:
 
 ```python
 from langchain_core.runnables import ensure_config
 
-async def build_fga_query(params):
+async def build_fga_query(tool_input):
     user_id = ensure_config().get("configurable",{}).get("user_id")
     return {
         "user": f"user:{user_id}",
-        "object": f"asset:{params.get("ticker")}",
+        "object": f"asset:{tool_input["ticker"]}",
         "relation": "can_buy",
         "context": {"current_time": datetime.now(timezone.utc).isoformat()}
     }
 
+def on_unauthorized(tool_input):
+    return f"The user is not allowed to buy {tool_input["qty"]} shares of {tool_input["ticker"]}."
+
 use_fga = fga(FGAAuthorizerOptions(
-    build_query=build_fga_query
+    build_query=build_fga_query,
+    on_unauthorized=on_unauthorized,
 ))
 ```
 
-**Note**: The parameters given to the `build_query` function are the same as those provided to the tool function.
+**Note**: The parameters given to the `build_query` and `on_unauthorized` functions are the same as those provided to the tool function.
 
 3. Wrap the tool:
 
 ```python
 from langchain_core.tools import StructuredTool
 
-async def buy_tool_function(auth: AuthParams, ticker: str, qty: int) -> str:
-    allowed = auth.get("allowed", False)
-    if allowed:
-        # TODO: implement buy operation
-        return f"Purchased {qty} shares of {ticker}"
-
-    return f"The user is not allowed to buy {ticker}."
+async def buy_tool_function(ticker: str, qty: int) -> str:
+    # TODO: implement buy operation
+    return f"Purchased {qty} shares of {ticker}"
 
 func=use_fga(buy_tool_function)
 

--- a/packages/langchain-auth0-ai/langchain_auth0_ai/fga/fga_authorizer.py
+++ b/packages/langchain-auth0-ai/langchain_auth0_ai/fga/fga_authorizer.py
@@ -1,4 +1,3 @@
-from auth0_ai.authorizers.types import AuthParams
 from auth0_ai.authorizers.fga_authorizer import FGAAuthorizer, FGAAuthorizerOptions
 
-__all__ = ["AuthParams", "FGAAuthorizer", "FGAAuthorizerOptions"]
+__all__ = ["FGAAuthorizer", "FGAAuthorizerOptions"]

--- a/packages/llama-index-auth0-ai/README.md
+++ b/packages/llama-index-auth0-ai/README.md
@@ -63,7 +63,7 @@ Example [Authorization for Tools](../../examples/authorization-for-tools/llama-i
 1. Create an instance of FGA Authorizer:
 
 ```python
-from langchain_auth0_ai.fga.fga_authorizer import AuthParams, FGAAuthorizer, FGAAuthorizerOptions
+from langchain_auth0_ai.fga.fga_authorizer import FGAAuthorizer, FGAAuthorizerOptions
 
 fga = FGAAuthorizer.create()
 ```
@@ -76,36 +76,36 @@ FGA_CLIENT_ID="<fga-client-id>"
 FGA_CLIENT_SECRET="<fga-client-secret>"
 ```
 
-2. Define the FGA query:
+2. Define the FGA query (`build_query`) and, optionally, the `on_unauthorized` handler:
 
 ```python
-def build_fga_query(params):
+def build_fga_query(tool_input):
     return {
         "user": f"user:{context.get("user_id")}",
-        "object": f"asset:{params.get("ticker")}",
+        "object": f"asset:{tool_input["ticker"]}",
         "relation": "can_buy",
         "context": {"current_time": datetime.now(timezone.utc).isoformat()}
     }
 
+def on_unauthorized(tool_input):
+    return f"The user is not allowed to buy {tool_input["qty"]} shares of {tool_input["ticker"]}."
+
 use_fga = fga(FGAAuthorizerOptions(
-    build_query=build_fga_query
+    build_query=build_fga_query,
+    on_unauthorized=on_unauthorized,
 ))
 ```
 
-**Note**: The parameters given to the `build_query` function are the same as those provided to the tool function.
+**Note**: The parameters given to the `build_query` and `on_unauthorized` functions are the same as those provided to the tool function.
 
 3. Wrap the tool:
 
 ```python
 from llama_index.core.tools import FunctionTool
 
-async def buy_tool_function(auth: AuthParams, ticker: str, qty: int) -> str:
-    allowed = auth.get("allowed", False)
-    if allowed:
+async def buy_tool_function(ticker: str, qty: int) -> str:
         # TODO: implement buy operation
         return f"Purchased {qty} shares of {ticker}"
-
-    return f"The user is not allowed to buy {ticker}."
 
 func=use_fga(buy_tool_function)
 

--- a/packages/llama-index-auth0-ai/llama_index_auth0_ai/fga/fga_authorizer.py
+++ b/packages/llama-index-auth0-ai/llama_index_auth0_ai/fga/fga_authorizer.py
@@ -1,4 +1,3 @@
-from auth0_ai.authorizers.types import AuthParams
 from auth0_ai.authorizers.fga_authorizer import FGAAuthorizer, FGAAuthorizerOptions
 
-__all__ = ["AuthParams", "FGAAuthorizer", "FGAAuthorizerOptions"]
+__all__ = ["FGAAuthorizer", "FGAAuthorizerOptions"]


### PR DESCRIPTION
```python
fga = FGAAuthorizer.create()

async def build_fga_query(tool_input):
    user_id = ensure_config().get("configurable",{}).get("user_id")
    return {
        "user": f"user:{user_id}",
        "object": f"asset:{tool_input["ticker"]}",
        "relation": "can_buy",
        "context": {"current_time": datetime.now(timezone.utc).isoformat()}
    }

def on_unauthorized(tool_input):
    return f"The user is not allowed to buy {tool_input["qty"]} shares of {tool_input["ticker"]}."

use_fga = fga(FGAAuthorizerOptions(
    build_query=build_fga_query,
    on_unauthorized=on_unauthorized,
))

async def buy_tool_function(ticker: str, qty: int) -> str:
    # TODO: implement buy operation
    return f"Purchased {qty} shares of {ticker}"

func=use_fga(buy_tool_function)
```