### PR TITLE
fix(type): get_credentials_for_connection returns TokenResponse not str

### DIFF
--- a/packages/auth0-ai/auth0_ai/authorizers/federated_connection_authorizer.py
+++ b/packages/auth0-ai/auth0_ai/authorizers/federated_connection_authorizer.py
@@ -42,7 +42,7 @@ async def _run_with_local_storage(data: AsyncStorageValue):
     finally:
         _local_storage.reset(token)
 
-def get_credentials_for_connection() -> str | None:
+def get_credentials_for_connection() -> TokenResponse | None:
     store = _get_local_storage()
     return store.get("credentials")
 


### PR DESCRIPTION
This pull request updates the return type of the `get_credentials_for_connection` function in `federated_connection_authorizer.py` to improve type clarity and correctness.

Type update:

* [`packages/auth0-ai/auth0_ai/authorizers/federated_connection_authorizer.py`](diffhunk://#diff-9ead16f28104bba84a6de68c730b9685d8b0e3d6060a68e526976a1b823e92ecL45-R45): Changed the return type of the `get_credentials_for_connection` function from `str | None` to `TokenResponse | None`, ensuring the type aligns with the expected structure of the returned data.