### PR TITLE
feat(federated-connection): add missing method get_access_token_for_connection

### DIFF
--- a/examples/calling-apis/llama-index-examples/src/agents/tools/list_repositories.py
+++ b/examples/calling-apis/llama-index-examples/src/agents/tools/list_repositories.py
@@ -2,19 +2,19 @@ from github import Github
 from github.GithubException import BadCredentialsException
 from llama_index.core.tools import FunctionTool
 
-from auth0_ai_llamaindex.federated_connections import FederatedConnectionError, get_credentials_for_connection
+from auth0_ai_llamaindex.federated_connections import FederatedConnectionError, get_access_token_for_connection
 from src.auth0.auth0_ai import with_github_access
 
 
 def list_repositories_tool_function():
-    credentials = get_credentials_for_connection()
-    if not credentials:
+    access_token = get_access_token_for_connection()
+    if not access_token:
         raise ValueError(
             "Authorization required to access the Federated Connection API")
 
     # GitHub SDK
     try:
-        g = Github(credentials["access_token"])
+        g = Github(access_token)
         user = g.get_user()
         repos = user.get_repos()
         repo_names = [repo.name for repo in repos]

--- a/packages/auth0-ai-langchain/auth0_ai_langchain/federated_connections/__init__.py
+++ b/packages/auth0-ai-langchain/auth0_ai_langchain/federated_connections/__init__.py
@@ -3,5 +3,8 @@ from auth0_ai.interrupts.federated_connection_interrupt import (
     FederatedConnectionInterrupt as FederatedConnectionInterrupt
 )
 
-from auth0_ai.authorizers.federated_connection_authorizer import get_credentials_for_connection as get_credentials_for_connection
+from auth0_ai.authorizers.federated_connection_authorizer import (
+    get_credentials_for_connection as get_credentials_for_connection,
+    get_access_token_for_connection as get_access_token_for_connection
+)
 from .federated_connection_authorizer import FederatedConnectionAuthorizer as FederatedConnectionAuthorizer

--- a/packages/auth0-ai-llamaindex/auth0_ai_llamaindex/federated_connections/__init__.py
+++ b/packages/auth0-ai-llamaindex/auth0_ai_llamaindex/federated_connections/__init__.py
@@ -3,5 +3,8 @@ from auth0_ai.interrupts.federated_connection_interrupt import (
     FederatedConnectionInterrupt as FederatedConnectionInterrupt
 )
 
-from auth0_ai.authorizers.federated_connection_authorizer import get_credentials_for_connection as get_credentials_for_connection
+from auth0_ai.authorizers.federated_connection_authorizer import (
+    get_credentials_for_connection as get_credentials_for_connection,
+    get_access_token_for_connection as get_access_token_for_connection
+)
 from auth0_ai_llamaindex.federated_connections.federated_connection_authorizer import FederatedConnectionAuthorizer as FederatedConnectionAuthorizer


### PR DESCRIPTION
This pull request updates the handling of federated connection credentials by introducing a new function, `get_access_token_for_connection`, and replacing the usage of `get_credentials_for_connection` where only the access token is required. These changes improve code clarity and ensure a more specific API is used for retrieving access tokens.

### Updates to credential handling:

* [`packages/auth0-ai/auth0_ai/authorizers/federated_connection_authorizer.py`](diffhunk://#diff-9ead16f28104bba84a6de68c730b9685d8b0e3d6060a68e526976a1b823e92ecR54-R57): Added a new function, `get_access_token_for_connection`, to retrieve only the access token from local storage.

### Code refactoring to use the new function:

* [`examples/calling-apis/llama-index-examples/src/agents/tools/list_repositories.py`](diffhunk://#diff-b391963c20e88cfd399d6b2126fa421eaf468e3969961aa9475dfda9c13d6847L5-R17): Replaced calls to `get_credentials_for_connection` with `get_access_token_for_connection` in the `list_repositories_tool_function` to directly retrieve the access token.

### Import updates for compatibility:

* [`packages/auth0-ai-langchain/auth0_ai_langchain/federated_connections/__init__.py`](diffhunk://#diff-ed3a5a93f84f12428173b48f0cc98bc834f810e969238868db3525c72f9a1a50L6-R9): Updated imports to include `get_access_token_for_connection` from `federated_connection_authorizer`.
* [`packages/auth0-ai-llamaindex/auth0_ai_llamaindex/federated_connections/__init__.py`](diffhunk://#diff-45bc8a9dfae90965a21238eae84a709b186b426c53e86c55d20ffe2b812b5927L6-R9): Updated imports to include `get_access_token_for_connection` from `federated_connection_authorizer`.