### PR TITLE
feat(ciba): support RAR requests

### DIFF
--- a/packages/auth0-ai-langchain/README.md
+++ b/packages/auth0-ai-langchain/README.md
@@ -58,6 +58,36 @@ trade_tool = with_async_user_confirmation(
 
 2. Handle interruptions properly. For example, if user is not enrolled to MFA, it will throw an interruption. See [Handling Interrupts](#handling-interrupts) section.
 
+### CIBA with RAR (Rich Authorization Requests)
+`Auth0AI` supports RAR (Rich Authorization Requests) for CIBA. This allows you to provide additional authorization parameters to be displayed during the user confirmation request.
+
+When defining the tool authorizer, you can specify the `authorization_details` parameter to include detailed information about the authorization being requested:
+
+```python
+with_async_user_confirmation = auth0_ai.with_async_user_confirmation(
+    scopes=["stock:trade"],
+    audience=os.getenv("AUDIENCE"),
+    binding_message=lambda ticker, qty: f"Authorize the purchase of {qty} {ticker}",
+    authorization_details=lambda ticker, qty: [
+        {
+            "type": "trade_authorization",
+            "qty": qty,
+            "ticker": ticker,
+            "action": "buy"
+        }
+    ],
+    user_id=lambda *_, **__: ensure_config().get("configurable", {}).get("user_id"),
+    # Optional:
+    # store=InMemoryStore()
+)
+```
+
+To use RAR with CIBA, you need to [set up authorization details](https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests) in your Auth0 tenant. This includes defining the authorization request parameters and their types. Additionally, the [Guardian SDK](https://auth0.com/docs/secure/multi-factor-authentication/auth0-guardian) is required to handle these authorization details in your authorizer app.
+
+For more information on setting up RAR with CIBA, refer to:
+- [Configure Rich Authorization Requests (RAR)](https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests)
+- [User Authorization with CIBA](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow/user-authorization-with-ciba)
+
 ## Authorization for Tools
 
 The `FGAAuthorizer` can leverage Okta FGA to authorize tools executions. The `FGAAuthorizer.create` function can be used to create an authorizer that checks permissions before executing the tool.

--- a/packages/auth0-ai-llamaindex/README.md
+++ b/packages/auth0-ai-llamaindex/README.md
@@ -58,6 +58,36 @@ trade_tool = with_async_user_confirmation(
 set_ai_context("<thread-id>")
 ```
 
+### CIBA with RAR (Rich Authorization Requests)
+`Auth0AI` supports RAR (Rich Authorization Requests) for CIBA. This allows you to provide additional authorization parameters to be displayed during the user confirmation request.
+
+When defining the tool authorizer, you can specify the `authorization_details` parameter to include detailed information about the authorization being requested:
+
+```python
+with_async_user_confirmation = auth0_ai.with_async_user_confirmation(
+    scopes=["stock:trade"],
+    audience=os.getenv("AUDIENCE"),
+    binding_message=lambda ticker, qty: f"Authorize the purchase of {qty} {ticker}",
+    authorization_details=lambda ticker, qty: [
+        {
+            "type": "trade_authorization",
+            "qty": qty,
+            "ticker": ticker,
+            "action": "buy"
+        }
+    ],
+    user_id=lambda *_, **__: ensure_config().get("configurable", {}).get("user_id"),
+    # Optional:
+    # store=InMemoryStore()
+)
+```
+
+To use RAR with CIBA, you need to [set up authorization details](https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests) in your Auth0 tenant. This includes defining the authorization request parameters and their types. Additionally, the [Guardian SDK](https://auth0.com/docs/secure/multi-factor-authentication/auth0-guardian) is required to handle these authorization details in your authorizer app.
+
+For more information on setting up RAR with CIBA, refer to:
+- [Configure Rich Authorization Requests (RAR)](https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests)
+- [User Authorization with CIBA](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow/user-authorization-with-ciba)
+
 ## Authorization for Tools
 
 The `FGAAuthorizer` can leverage Okta FGA to authorize tools executions. The `FGAAuthorizer.create` function can be used to create an authorizer that checks permissions before executing the tool.

--- a/packages/auth0-ai/auth0_ai/authorizers/ciba/ciba_authorizer_params.py
+++ b/packages/auth0-ai/auth0_ai/authorizers/ciba/ciba_authorizer_params.py
@@ -3,14 +3,16 @@ from auth0_ai.authorizers.context import AuthContext
 from auth0_ai.authorizers.types import ToolInput
 from auth0_ai.stores import Store
 
+
 class CIBAAuthorizerParams(TypedDict, Generic[ToolInput]):
     """
     Authorize Options to start CIBA flow.
 
     Attributes:
         scope (list[str]): The scopes to request authorization for.
-        binding_message (Union[str, Callable[..., Awaitable[str]]]): A human-readable string to display to the user, or a function that resolves it.
-        user_id (Union[str, Callable[..., Awaitable[str]]]): The user id string, or a function that resolves it.
+        binding_message (Union[str, Callable[..., str], Callable[..., Awaitable[str]]]): A human-readable string to display to the user, or a function that resolves it.
+        user_id (Union[str, Callable[..., str], Callable[..., Awaitable[str]]]): The user id string, or a function that resolves it.
+        authorization_details (Union[list[dict], Callable[..., list[dict]], Callable[..., Awaitable[list[dict]]]], optional):The authorization requirements list (e.g., [{ type: "custom_type", param: "example", ...}]), or a function that resolves it. More info: https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow/user-authorization-with-ciba
         store (Store, optional): An store used to temporarly store the authorization response data while the user is completing the authorization in another device (default: InMemoryStore).
         audience (str, optional): The audience to request authorization for.
         request_expiry (int, optional): The time in seconds for the authorization request to expire, pass a number between 1 and 300 (default: 300 seconds = 5 minutes).
@@ -24,8 +26,21 @@ class CIBAAuthorizerParams(TypedDict, Generic[ToolInput]):
             - "tool": Credentials are shared across multiple calls to the same tool within the same thread.
     """
     scopes: list[str]
-    binding_message: Union[str, Callable[ToolInput, Awaitable[str]]]
-    user_id: Union[str, Callable[ToolInput, Awaitable[str]]]
+    binding_message: Union[
+        str,
+        Callable[ToolInput, str],
+        Callable[ToolInput, Awaitable[str]]
+    ]
+    user_id: Union[
+        str,
+        Callable[ToolInput, str],
+        Callable[ToolInput, Awaitable[str]]
+    ]
+    authorization_details: Optional[Union[
+        list[dict],
+        Callable[ToolInput, list[dict]],
+        Callable[ToolInput, Awaitable[list[dict]]]
+    ]]
     store: Optional[Store]
     audience: Optional[str]
     request_expiry: Optional[int]


### PR DESCRIPTION
This pull request introduces support for handling `authorization_details` in the CIBA (Client-Initiated Backchannel Authentication) authorization flow. The changes allow `authorization_details` to be specified as either a static list of dictionaries or a callable that resolves to such a list. Below are the key updates:

### Enhancements to CIBA Authorization Flow:

* **Support for `authorization_details` in `_get_authorize_params`:** Updated the `_get_authorize_params` method in `ciba_authorizer_base.py` to handle `authorization_details` dynamically. It checks whether `authorization_details` is a list, a coroutine function, or a callable, and processes it accordingly.

* **New `authorization_details` attribute in `CIBAAuthorizerParams`:** Added the `authorization_details` attribute to the `CIBAAuthorizerParams` class in `ciba_authorizer_params.py`. This attribute can either be a list of dictionaries or a callable that resolves to such a list, providing more flexibility in specifying authorization details. [[1]](diffhunk://#diff-c4b795560d911fbbf435a3d34fb5c94a188de80f53c9a7b8cb4788a2d6a2669aR6-R17) [[2]](diffhunk://#diff-c4b795560d911fbbf435a3d34fb5c94a188de80f53c9a7b8cb4788a2d6a2669aR33)