### PR TITLE
fix(ciba): renamed scope to scopes as list[str] as it should have been

### DIFF
--- a/examples/async-user-confirmation/langchain-examples/src/agents/conditional_trade.py
+++ b/examples/async-user-confirmation/langchain-examples/src/agents/conditional_trade.py
@@ -103,7 +103,7 @@ def check_trade_status(state: State):
 auth0_ai = Auth0AI()
 protect_tool = auth0_ai.with_async_user_confirmation(
     audience=os.getenv("AUDIENCE"),
-    scope="stock:trade",
+    scopes=["stock:trade"],
     binding_message=lambda ticker, qty: f"Authorize the purchase of {qty} {ticker}",
     user_id=lambda *_, **__: ensure_config().get("configurable", {}).get("user_id")
 )

--- a/examples/async-user-confirmation/llama-index-examples/src/auth0/auth0_ai.py
+++ b/examples/async-user-confirmation/llama-index-examples/src/auth0/auth0_ai.py
@@ -15,7 +15,7 @@ async def user_id(**_kwargs):
     return user.get("sub")
 
 with_async_user_confirmation = auth0_ai.with_async_user_confirmation(
-    scope="stock:trade",
+    scopes=["stock:trade"],
     audience=os.getenv("AUDIENCE"),
     binding_message=lambda ticker, qty: f"Authorize the purchase of {qty} {ticker}",
     user_id=user_id,

--- a/packages/auth0-ai-langchain/README.md
+++ b/packages/auth0-ai-langchain/README.md
@@ -30,7 +30,7 @@ from langchain_core.tools import StructuredTool
 auth0_ai = Auth0AI()
 
 with_async_user_confirmation = auth0_ai.with_async_user_confirmation(
-    scope="stock:trade",
+    scopes=["stock:trade"],
     audience=os.getenv("AUDIENCE"),
     binding_message=lambda ticker, qty: f"Authorize the purchase of {qty} {ticker}",
     user_id=lambda *_, **__: ensure_config().get("configurable", {}).get("user_id"),

--- a/packages/auth0-ai-langchain/auth0_ai_langchain/auth0_ai.py
+++ b/packages/auth0-ai-langchain/auth0_ai_langchain/auth0_ai.py
@@ -44,7 +44,7 @@ class Auth0AI:
             auth0_ai = Auth0AI()
 
             with_async_user_confirmation = auth0_ai.with_async_user_confirmation(
-                scope="stock:trade",
+                scopes=["stock:trade"],
                 audience=os.getenv("AUDIENCE"),
                 binding_message=lambda ticker, qty: f"Authorize the purchase of {qty} {ticker}",
                 user_id=lambda *_, **__: ensure_config().get("configurable", {}).get("user_id")
@@ -108,5 +108,6 @@ class Auth0AI:
             )
             ```
         """
-        authorizer = FederatedConnectionAuthorizer(FederatedConnectionAuthorizerParams(**params), self.auth0)
+        authorizer = FederatedConnectionAuthorizer(
+            FederatedConnectionAuthorizerParams(**params), self.auth0)
         return authorizer.authorizer()

--- a/packages/auth0-ai-llamaindex/README.md
+++ b/packages/auth0-ai-llamaindex/README.md
@@ -29,7 +29,7 @@ from llama_index.core.tools import FunctionTool
 auth0_ai = Auth0AI()
 
 with_async_user_confirmation = auth0_ai.with_async_user_confirmation(
-    scope="stock:trade",
+    scopes=["stock:trade"],
     audience=os.getenv("AUDIENCE"),
     binding_message=lambda ticker, qty: f"Authorize the purchase of {qty} {ticker}",
     user_id=lambda *_, **__: session["user"]["userinfo"]["sub"],

--- a/packages/auth0-ai-llamaindex/auth0_ai_llamaindex/auth0_ai.py
+++ b/packages/auth0-ai-llamaindex/auth0_ai_llamaindex/auth0_ai.py
@@ -7,6 +7,7 @@ from auth0_ai_llamaindex.ciba.ciba_authorizer import CIBAAuthorizer
 from auth0_ai_llamaindex.federated_connections.federated_connection_authorizer import FederatedConnectionAuthorizer
 from auth0_ai_llamaindex.context import set_ai_context
 
+
 class Auth0AI:
     """Provides decorators to secure LlamaIndex tools using Auth0 authorization flows.
     """
@@ -60,7 +61,8 @@ class Auth0AI:
             )
             ```
         """
-        authorizer = FederatedConnectionAuthorizer(FederatedConnectionAuthorizerParams(**params), self.auth0)
+        authorizer = FederatedConnectionAuthorizer(
+            FederatedConnectionAuthorizerParams(**params), self.auth0)
         return authorizer.authorizer()
 
     def with_async_user_confirmation(self, **params: CIBAAuthorizerParams) -> Callable[[FunctionTool], FunctionTool]:
@@ -85,7 +87,7 @@ class Auth0AI:
             auth0_ai = Auth0AI()
 
             with_async_user_confirmation = auth0_ai.with_async_user_confirmation(
-                scope="stock:trade",
+                scopes=["stock:trade"],
                 audience=os.getenv("AUDIENCE"),
                 binding_message=lambda ticker, qty: f"Authorize the purchase of {qty} {ticker}",
                 user_id=lambda *_, **__: session["user"]["userinfo"]["sub"]
@@ -110,5 +112,6 @@ class Auth0AI:
         """
         authorizer = CIBAAuthorizer(CIBAAuthorizerParams(**params), self.auth0)
         return authorizer.authorizer()
+
 
 __all__ = ["Auth0AI", "set_ai_context"]

--- a/packages/auth0-ai/auth0_ai/authorizers/ciba/ciba_authorizer_base.py
+++ b/packages/auth0-ai/auth0_ai/authorizers/ciba/ciba_authorizer_base.py
@@ -54,8 +54,7 @@ def get_ciba_credentials() -> TokenResponse | None:
     local_store = _get_local_storage()
     return local_store.get("credentials")
 
-def _ensure_openid_scope(scope: str) -> str:
-    scopes = scope.strip().split()
+def _ensure_openid_scope(scopes: list[str]) -> str:
     if "openid" not in scopes:
         scopes.insert(0, "openid")
     return " ".join(scopes)
@@ -105,7 +104,7 @@ class CIBAAuthorizerBase(Generic[ToolInput]):
 
     async def _get_authorize_params(self, *args: ToolInput.args, **kwargs: ToolInput.kwargs) -> Dict[str, Any]:
         authorize_params = {
-            "scope": _ensure_openid_scope(self.params.get("scope")),
+            "scope": _ensure_openid_scope(self.params.get("scopes")),
             "audience": self.params.get("audience"),
             "request_expiry": self.params.get("request_expiry"),
         }

--- a/packages/auth0-ai/auth0_ai/authorizers/ciba/ciba_authorizer_params.py
+++ b/packages/auth0-ai/auth0_ai/authorizers/ciba/ciba_authorizer_params.py
@@ -9,7 +9,7 @@ class CIBAAuthorizerParams(TypedDict, Generic[ToolInput]):
     Authorize Options to start CIBA flow.
 
     Attributes:
-        scope (list[str]): The scopes to request authorization for.
+        scopes (list[str]): The scopes to request authorization for.
         binding_message (Union[str, Callable[..., str], Callable[..., Awaitable[str]]]): A human-readable string to display to the user, or a function that resolves it.
         user_id (Union[str, Callable[..., str], Callable[..., Awaitable[str]]]): The user id string, or a function that resolves it.
         authorization_details (Union[list[dict], Callable[..., list[dict]], Callable[..., Awaitable[list[dict]]]], optional):The authorization requirements list (e.g., [{ type: "custom_type", param: "example", ...}]), or a function that resolves it. More info: https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow/user-authorization-with-ciba


### PR DESCRIPTION
This pull request introduces several updates across multiple files to standardize the use of `scopes` (a list) instead of `scope` (a string) in the authorization flow, along with some minor refactoring for improved readability. Below is a summary of the most important changes grouped by theme:

### Standardization of `scopes` Parameter:
* Replaced `scope="stock:trade"` with `scopes=["stock:trade"]` in various examples and function calls, ensuring consistency in how scopes are handled across the codebase. (`examples/async-user-confirmation/llama-index-examples/src/auth0/auth0_ai.py` [[1]](diffhunk://#diff-add7a4d44f8ddde5911d7389ea416ca34544dac1be49b3a7d378ee5f5c6e97b3L18-R18) `packages/auth0-ai-langchain/README.md` [[2]](diffhunk://#diff-52d39e2c6aaa8b2e0297936cb80d4ba6b9e6225ed0a65a8d46c97568684a9cadL33-R33) `packages/auth0-ai-langchain/auth0_ai_langchain/auth0_ai.py` [[3]](diffhunk://#diff-144aa5d66347b0636f7345be06af700e8fd7ef99ef29fa3e2c220450ce349f4aL47-R47) [[4]](diffhunk://#diff-144aa5d66347b0636f7345be06af700e8fd7ef99ef29fa3e2c220450ce349f4aL111-R112) `packages/auth0-ai-llamaindex/README.md` [[5]](diffhunk://#diff-3a533a8ac6fbd0188c8d5034bf8b997cc991e1a99fe0d1921f04277714d7c8c0L32-R32) `packages/auth0-ai-llamaindex/auth0_ai_llamaindex/auth0_ai.py` [[6]](diffhunk://#diff-ea69855660f8f445b7f4851e20c63ff8b9b893d2f64d23c89603314a42e1f282L88-R90))

* Updated the `CIBAAuthorizerParams` type definition to use `scopes` instead of `scope`. (`packages/auth0-ai/auth0_ai/authorizers/ciba/ciba_authorizer_params.py`)

* Modified `_ensure_openid_scope` to accept a list of scopes instead of a single string, aligning it with the updated parameter format. (`packages/auth0-ai/auth0_ai/authorizers/ciba/ciba_authorizer_base.py` [[1]](diffhunk://#diff-b738c89b9d4bf313530564d5ad20b9bda66008486e4b4fb9aecbb3908788cad7L57-R57) [[2]](diffhunk://#diff-b738c89b9d4bf313530564d5ad20b9bda66008486e4b4fb9aecbb3908788cad7L108-R107))

### Code Readability Improvements:
* Reformatted the instantiation of `FederatedConnectionAuthorizer` to improve readability by splitting long lines. (`packages/auth0-ai-langchain/auth0_ai_langchain/auth0_ai.py` [[1]](diffhunk://#diff-144aa5d66347b0636f7345be06af700e8fd7ef99ef29fa3e2c220450ce349f4aL111-R112) `packages/auth0-ai-llamaindex/auth0_ai_llamaindex/auth0_ai.py` [[2]](diffhunk://#diff-ea69855660f8f445b7f4851e20c63ff8b9b893d2f64d23c89603314a42e1f282L63-R65))

* Added a blank line after imports to adhere to PEP 8 style guidelines. (`packages/auth0-ai-llamaindex/auth0_ai_llamaindex/auth0_ai.py`)

These changes improve the consistency and maintainability of the codebase while adhering to best practices for parameter handling and code readability.