### PR TITLE
release: 1.0.0b3

### DIFF
--- a/packages/auth0-ai-langchain/poetry.lock
+++ b/packages/auth0-ai-langchain/poetry.lock
@@ -186,7 +186,7 @@ tests-mypy = ["mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" a
 
 [[package]]
 name = "auth0-ai"
-version = "1.0.0b2"
+version = "1.0.0b3"
 description = "This package provides base abstractions for authentication and authorization in AI applications."
 optional = false
 python-versions = "^3.11"
@@ -195,8 +195,8 @@ files = []
 develop = true
 
 [package.dependencies]
-auth0-python = "^4.9.0"
-openfga-sdk = "^0.9.4"
+auth0-python = "^4.10.0"
+openfga-sdk = "^0.9.5"
 
 [package.source]
 type = "directory"
@@ -204,14 +204,14 @@ url = "../auth0-ai"
 
 [[package]]
 name = "auth0-python"
-version = "4.9.0"
+version = "4.10.0"
 description = ""
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "auth0_python-4.9.0-py3-none-any.whl", hash = "sha256:6440c7f74dfd669d9f5cdfe9bb44c4c3b230ce98a82353f55a387e90241fbf5b"},
-    {file = "auth0_python-4.9.0.tar.gz", hash = "sha256:f9b31ea9c906d0a123b9cdc6ccd7bbbb8156123f44789b08571c45947fb21238"},
+    {file = "auth0_python-4.10.0-py3-none-any.whl", hash = "sha256:c005cebbbe66bbfaa593353be76d7c9d52dc41fcb9680f815067496d5f3a9968"},
+    {file = "auth0_python-4.10.0.tar.gz", hash = "sha256:fca0f29cd32618803b59a940041ee78c6304de9ab5a02cd7863f82951affdee6"},
 ]
 
 [package.dependencies]

--- a/packages/auth0-ai-langchain/pyproject.toml
+++ b/packages/auth0-ai-langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auth0-ai-langchain"
-version = "1.0.0b2"
+version = "1.0.0b3"
 description = "This package is an SDK for building secure AI-powered applications using Auth0, Okta FGA and LangChain."
 license = "apache-2.0"
 homepage = "https://auth0.com"
@@ -14,7 +14,7 @@ langchain = "^0.3.26"
 langgraph-sdk = "^0.1.73"
 langchain-core = "^0.3.69"
 langgraph = "^0.5.3"
-# auth0-ai = "^1.0.0b2"
+# auth0-ai = "^1.0.0b3"
 auth0-ai = { path = "../auth0-ai", develop = true }
 
 [tool.poetry.group.test.dependencies]

--- a/packages/auth0-ai-llamaindex/poetry.lock
+++ b/packages/auth0-ai-llamaindex/poetry.lock
@@ -205,7 +205,7 @@ tests-mypy = ["mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" a
 
 [[package]]
 name = "auth0-ai"
-version = "1.0.0b2"
+version = "1.0.0b3"
 description = "This package provides base abstractions for authentication and authorization in AI applications."
 optional = false
 python-versions = "^3.11"

--- a/packages/auth0-ai-llamaindex/pyproject.toml
+++ b/packages/auth0-ai-llamaindex/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auth0-ai-llamaindex"
-version = "1.0.0b2"
+version = "1.0.0b3"
 description = "This package is an SDK for building secure AI-powered applications using Auth0, Okta FGA and LlamaIndex."
 license = "apache-2.0"
 homepage = "https://auth0.com"
@@ -11,7 +11,7 @@ readme = "README.md"
 python = "^3.11"
 llama-index = "^0.12.49"
 openfga-sdk = "^0.9.5"
-# auth0-ai = "^1.0.0b2"
+# auth0-ai = "^1.0.0b3"
 auth0-ai = { path = "../auth0-ai", develop = true }
 
 [tool.poetry.group.test.dependencies]

--- a/packages/auth0-ai/pyproject.toml
+++ b/packages/auth0-ai/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auth0-ai"
-version = "1.0.0b2"
+version = "1.0.0b3"
 description = "This package provides base abstractions for authentication and authorization in AI applications."
 license = "apache-2.0"
 homepage = "https://auth0.com"


### PR DESCRIPTION
This pull request updates the version of three related Python packages (`auth0-ai-langchain`, `auth0-ai-llamaindex`, and `auth0-ai`) from `1.0.0b2` to `1.0.0b3` and ensures consistency in their dependencies.

### Version updates:

* Updated the version of the `auth0-ai-langchain` package to `1.0.0b3` in `pyproject.toml` (`packages/auth0-ai-langchain/pyproject.toml`).
* Updated the version of the `auth0-ai-llamaindex` package to `1.0.0b3` in `pyproject.toml` (`packages/auth0-ai-llamaindex/pyproject.toml`).
* Updated the version of the `auth0-ai` package to `1.0.0b3` in `pyproject.toml` (`packages/auth0-ai/pyproject.toml`).

### Dependency updates:

* Updated the commented-out dependency reference for `auth0-ai` to reflect version `1.0.0b3` in `auth0-ai-langchain` (`packages/auth0-ai-langchain/pyproject.toml`).
* Updated the commented-out dependency reference for `auth0-ai` to reflect version `1.0.0b3` in `auth0-ai-llamaindex` (`packages/auth0-ai-llamaindex/pyproject.toml`).